### PR TITLE
refactor: refactor print_random function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -400,11 +400,9 @@ fn merge_maps(maps: &[Map], order: &[usize]) -> Map {
 
 fn print_random_bs(map: &mut Map, beacons: &[usize]) {
     let mut positions = Vec::new();
-    let mut remaining = beacons.len();
 
     for beacon in beacons {
-        for row in 0..map.height {
-            let mut breaking = false;
+        'mid: for row in 0..map.height {
             for col in 0..map.width {
                 if map.grid[row][col].field_type == MapFieldType::Node || map.grid[row][col].covered
                 {
@@ -414,14 +412,9 @@ fn print_random_bs(map: &mut Map, beacons: &[usize]) {
                 let radius = effective_radius(map, &Position { row, col }, *beacon);
                 map.put_beacon(&Position { row, col }, radius);
                 positions.push(Position { row, col });
-                remaining -= 1;
-                breaking = true;
                 map.grid[row][col].covered = true;
 
-                break;
-            }
-            if breaking {
-                break;
+                break 'mid;
             }
         }
     }


### PR DESCRIPTION
- Previously I used a bool to indicate if I should break out of the middle loop, but its not needed since its possible to assign a name to a loop and then specify exactly which loop to break out of.
- Removed the unused variable `remaining`