### PR TITLE
revert: Revert avoiding beacon radius cutoff by border

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,20 +269,15 @@ fn try_map(map: &mut Map, beacons: &[usize]) -> (isize, Vec<Position>) {
 
     for beacon in beacons {
         let mut max: Vec<(isize, Position)> = Vec::new();
-        let start = if *beacon < map.height && *beacon < map.width {
-            *beacon
-        } else {
-            0
-        };
-
-        for row in start..map.height - start {
+        // Maybe don't start at the border
+        for row in 0..map.height {
             let mut prev_pos = None;
             let mut prev_value = None;
             let mut prev_radius = None;
 
             // Splitting the loop like this makes it 10% faster (somehow)
             if row % 2 == 0 {
-                for col in start..map.width - start {
+                for col in 0..map.width {
                     if map.grid[row][col].field_type == MapFieldType::Node
                         || map.grid[row][col].covered
                     {
@@ -305,7 +300,7 @@ fn try_map(map: &mut Map, beacons: &[usize]) -> (isize, Vec<Position>) {
                     prev_radius = Some(radius);
                 }
             } else {
-                for col in (start..map.width - start).rev() {
+                for col in (0..map.width).rev() {
                     if map.grid[row][col].field_type == MapFieldType::Node
                         || map.grid[row][col].covered
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ fn try_map(map: &mut Map, beacons: &[usize]) -> (isize, Vec<Position>) {
 
     for beacon in beacons {
         let mut max: Vec<(isize, Position)> = Vec::new();
-        // Maybe don't start at the border
+        // TODO Maybe don't start at the border
         for row in 0..map.height {
             let mut prev_pos = None;
             let mut prev_value = None;
@@ -325,7 +325,7 @@ fn try_map(map: &mut Map, beacons: &[usize]) -> (isize, Vec<Position>) {
             }
         }
 
-        // Check the other results too
+        // TODO Check the other results too
         let radius = effective_radius(map, &max[0].1, *beacon);
         map.put_beacon(&max[0].1, radius);
         map.grid[max[0].1.row][max[0].1.col].covered = true;


### PR DESCRIPTION
Commit 824ff11 caused a panic when the radius of a beacon was higher than the map-width / 2 or no free spot was found in the smaller search area.

Reverting this does make the program slower.

The best solution would be to **first** start searching so that none of the beacon's radius gets cut off by the border.
But if in that middle section of the map no place to put the beacon was found, **then** it should start going outwards, without checking rows and columns again that have already been searched.
I don't have time to implement that at the moment though.